### PR TITLE
Fix composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "atkins/t3-trix",
-  "type": "typo3-cms-framework",
+  "type": "typo3-cms-extension",
   "description": "A Trix Rich Text Editor Integration for TYPO3 CMS",
   "homepage": "https://github.com/colinatkins/t3-trix",
   "license": [


### PR DESCRIPTION
The type for a TYPO3 third-party extension must be "typo3-cms-extension".

This is necessary for the documenation rendering, so it can be approved.